### PR TITLE
feat: remove es2016 preset

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,8 +1,7 @@
 {
   "presets": [
     "es2015",
-    "es2016",
     "stage-0",
     "react"
-  ],
+  ]
 }


### PR DESCRIPTION
`yarn build` doesn't work with it, but removing it from config does not affect builded files at all 🤷 